### PR TITLE
Implemented alert hiding option

### DIFF
--- a/html/options.html
+++ b/html/options.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+  </head>
+  <body>
+    <div>
+      <input type="checkbox" id="disable-video-text" />
+      <label for="disable-video-text">Disable video window text</label>
+    </div>
+    <script src="../js/options.js"></script>
+  </body>
+</html>

--- a/js/options.js
+++ b/js/options.js
@@ -1,0 +1,20 @@
+// Fetch references to the options' corresponding HTML elements
+var disableVideoTextCheckbox = document.getElementById("disable-video-text");
+
+// Initialize option elements (register listeners & set initial states)
+if (disableVideoTextCheckbox) {
+  // Register listeners
+  disableVideoTextCheckbox.addEventListener("change", optionChanged);
+
+  // Set states
+  chrome.storage.local.get('disable_video_text', function(values) {
+    disableVideoTextCheckbox.checked = (values.disable_video_text ? true : false);
+  });
+}
+  
+// Save options as they're modified
+function optionChanged() {
+  chrome.storage.local.set({
+    "disable_video_text": disableVideoTextCheckbox.checked
+  });
+}

--- a/js/youtube_audio.js
+++ b/js/youtube_audio.js
@@ -13,6 +13,7 @@ chrome.runtime.onMessage.addListener(
         let videoElement = document.getElementsByTagName('video')[0];
         videoElement.onloadeddata = makeSetAudioURL(videoElement, url);
         let audioOnlyDivs = document.getElementsByClassName('audio_only_div');
+        // Append alert text
         if (audioOnlyDivs.length == 0) {
             let extensionAlert = document.createElement('div');
             extensionAlert.className = 'audio_only_div';
@@ -25,7 +26,13 @@ chrome.runtime.onMessage.addListener(
 
             extensionAlert.appendChild(alertText);
             let parent = videoElement.parentNode.parentNode;
-            parent.appendChild(extensionAlert);
+
+            // Append alert only if options specify to do so
+            chrome.storage.local.get('disable_video_text', function(values) {
+              var disableVideoText = (values.disable_video_text ? true : false);
+              if (!disableVideoText)
+                parent.appendChild(extensionAlert);
+            });
         }
         else if (url == "") {
             for(div in audioOnlyDivs) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,16 @@
 {
   "name": "Youtube Audio",
-  "version": "0.0.2.3",
+  "version": "0.0.2.4",
   "manifest_version": 2,
   "description": "Stream only Audio on Youtube",
   "icons": {
     "38": "img/icon38.png",
     "128": "img/icon128.png"
+  },
+  "applications": {
+    "gecko": {
+      "id": "youtube-audio@whompingwalr.us"
+    }
   },
   "background": {
     "scripts": [
@@ -37,5 +42,10 @@
       ],
       "run_at": "document_start"
     }
-  ]
+  ],
+  "options_ui": {
+    "page": "html/options.html",
+    "browser_style": true,
+    "chrome_style": true
+  }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
   "permissions": [
     "tabs",
     "webRequest",
-    "*://*youtube.com*",
+    "*://*/*",
     "webRequestBlocking",
     "storage"
   ],


### PR DESCRIPTION
Reverted to last functional version as highlighted in issue #12 .

Implemented options page and the ability to toggle video overlay warning on/off as per feature request #9 .  These are two separate commits.

Needed to add an ID of my own in order to sign it for installation.  Feel free to replace the ID with your own, animeshkundu (:  Should have your name on it if anyone's.

In the meanwhile, I've signed and released a functional version with the global permissions restored and text alert toggle option implemented (in my own cloned repo), for anyone else who's impatient like I am.