### PR TITLE
Add youtube-nocookie domain support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,8 @@
     {
       "all_frames": true,
       "matches": [
-        "*://*.youtube.com/*"
+        "*://*.youtube.com/*",
+        "*://*.youtube-nocookie.com/*"
       ],
       "js": [
         "js/youtube_audio.js"


### PR DESCRIPTION
Fixes #22 

"www.youtube-nocookie.com" is a "privacy-enhanced" version of the site which can be used for embed links.

Info [here](https://support.google.com/youtube/answer/171780) under the "Turn on privacy-enhanced mode" bullet.

Example: "https://www.youtube.com/watch?v=aqz-KE-bpKQ" would become "https://www.youtube-nocookie.com/embed/aqz-KE-bpKQ"