### PR TITLE
Document Fenix live RDP preference requirement

### DIFF
--- a/docs/history/2026-08-03-mobile-hermetic-rdp-readiness.md
+++ b/docs/history/2026-08-03-mobile-hermetic-rdp-readiness.md
@@ -17,6 +17,9 @@ the temporary BENCH XPI through the Firefox Android RDP add-ons actor.
 - The probe fails closed unless Fenix creates its native debugger socket. It then forwards that socket
   and uses the RDP add-ons actor, because Fenix 128 rejects WebDriver temporary installation and later
   releases did not attach content scripts after the WebDriver command.
+- A direct preference write is not a reliable substitute: Fenix's preference-change listener updates
+  both its stored preference and the live Gecko runtime setting, so storage alone does not enable RDP
+  in the running app.
 - The fixture is mapped to emulator loopback with `adb reverse`, which supplies both the BENCH media
   allowlist route and the secure context required by the bridge. The probe still requires granted
   consent, `active` status, a `/videoplayback` source, and a fixture player POST.


### PR DESCRIPTION
Records the Fenix source-backed reason the hermetic probe must toggle Remote debugging via the live settings UI: a direct stored-preference write does not update the running Gecko runtime.

The functional Marionette-first, hierarchy-validated RDP path is already present on `master`; this pull request retains the existing five-version gating behavior and causes it to be requalified.