### PR TITLE
Clean up Fenix hermetic RDP forwarding

### DIFF
--- a/docs/history/2026-08-03-mobile-hermetic-rdp-readiness.md
+++ b/docs/history/2026-08-03-mobile-hermetic-rdp-readiness.md
@@ -15,8 +15,12 @@ the temporary BENCH XPI through the Firefox Android RDP add-ons actor.
   adb and uiautomator failures with backoff, verifies that the dump file exists and is non-empty before
   parsing, accepts menu and secret-settings layouts, and includes raw command and dump output on failure.
 - The probe fails closed unless Fenix creates its native debugger socket. It then forwards that socket
-  and uses the RDP add-ons actor, because Fenix 128 rejects WebDriver temporary installation and later
-  releases did not attach content scripts after the WebDriver command.
+  and uses the RDP add-ons actor, removing the temporary forward after every attempt. Fenix 128 rejects
+  WebDriver temporary installation and later releases did not attach content scripts after the WebDriver
+  command.
+- A direct preference write is not a reliable substitute: Fenix's preference-change listener updates
+  both its stored preference and the live Gecko runtime setting, so storage alone does not enable RDP
+  in the running app.
 - The fixture is mapped to emulator loopback with `adb reverse`, which supplies both the BENCH media
   allowlist route and the secure context required by the bridge. The probe still requires granted
   consent, `active` status, a `/videoplayback` source, and a fixture player POST.

--- a/tests/e2e/android/probe-hermetic-fixture.mjs
+++ b/tests/e2e/android/probe-hermetic-fixture.mjs
@@ -128,10 +128,14 @@ async function installAndroidAddonViaRdp() {
   const socketTarget = socket.startsWith('@')
     ? `localabstract:${socket.slice(1)}`
     : `localfilesystem:${socket}`;
-  await adb('forward', `tcp:${port}`, socketTarget);
 
   let remoteFirefox;
+  let forwarded = false;
+  let primaryError;
+  let installResult;
   try {
+    await adb('forward', `tcp:${port}`, socketTarget);
+    forwarded = true;
     remoteFirefox = await connectWithMaxRetries({
       port,
       maxRetries: RDP_CONNECT_RETRIES,
@@ -142,10 +146,41 @@ async function installAndroidAddonViaRdp() {
     if (addonId !== ADDON_ID) {
       throw new Error(`RDP installed unexpected add-on: ${JSON.stringify(result)}`);
     }
-    return { addonId, socket, port };
-  } finally {
-    remoteFirefox?.disconnect();
+    installResult = { addonId, socket, port };
+  } catch (error) {
+    primaryError = error;
   }
+
+  const cleanupErrors = [];
+  try {
+    await remoteFirefox?.disconnect();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  if (forwarded) {
+    try {
+      await adb('forward', '--remove', `tcp:${port}`);
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+
+  if (primaryError) {
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [primaryError, ...cleanupErrors],
+        `Fenix RDP failed and its adb forward tcp:${port} could not be removed`
+      );
+    }
+    throw primaryError;
+  }
+  if (cleanupErrors.length === 1) {
+    throw cleanupErrors[0];
+  }
+  if (cleanupErrors.length > 1) {
+    throw new AggregateError(cleanupErrors, `Fenix RDP cleanup failed for adb forward tcp:${port}`);
+  }
+  return installResult;
 }
 
 async function snapshot(driver) {


### PR DESCRIPTION
## Summary

- remove the temporary RDP `adb forward` after each temporary add-on install attempt
- preserve both the primary RDP failure and any cleanup failure
- document the cleanup and why UI-driven remote-debugging remains necessary

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test` (278 tests)

The hermetic probe continues to require seeded consent, `active` status, `/videoplayback` hijack, and a fixture player POST.